### PR TITLE
Refactoring. Avoid strings for emulation ADTs

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var pc = require("./index.js");
+const pc = require("./index.js");
 
 // Applies not 4b times
 const many_nots = `
@@ -40,7 +40,7 @@ const unscoped = `
 `;
 
 const run_example = (name, example) => {
-  var env = pc.syntax.parse(example);
+  const env = pc.syntax.parse(example);
   console.log("Running", name);
   console.log("- norm:", pc.syntax.show(pc.core.reduce(env.main(), env)));
   console.log("- rwts:", env._rwts);

--- a/syntax.js
+++ b/syntax.js
@@ -2,27 +2,34 @@ const {Var, Lam, App, Par, Let, reduce, fresh, copy} = require("./core.js");
 
 // Stringifier
 function show(term) {
-  switch (term.ctor) {
-    case "Var":
+  switch (term.tag) {
+    case Var: {
       return term.name;
-    case "Lam":
-      var name = term.name;
-      var body = show(term.body);
-      return "{" + name + "} " + body;
-    case "App":
-      var func = show(term.func);
-      var argm = show(term.argm);
-      return "(" + func + " " + argm + ")";
-    case "Par":
-      var val0 = show(term.val0);
-      var val1 = show(term.val1);
-      return "[" + val0 + "," + val1 + "]";
-    case "Let":
-      var nam0 = term.nam0;
-      var nam1 = term.nam1;
-      var expr = show(term.expr);
-      var body = show(term.body);
-      return "get [" + nam0 + "," + nam1 + "] = " + expr + "; " + body;
+    }
+    case Lam: {
+      const name = term.name;
+      const body = show(term.body);
+      return `${name} ${body}`;
+    }
+    case App: {
+      const func = show(term.func);
+      const argm = show(term.argm);
+      return `(${func} ${argm })`;
+    }
+    case Par: {
+      const val0 = show(term.val0);
+      const val1 = show(term.val1);
+      return `[${val0},${val1}]`;
+    }
+    case Let: {
+      const nam0 = term.nam0;
+      const nam1 = term.nam1;
+      const expr = show(term.expr);
+      const body = show(term.body);
+      return `get [${nam0},${nam1}] = ${expr}; ${body}`;
+    }
+    default:
+      return '<unknown term>';
   }
 };
 
@@ -45,9 +52,9 @@ function parse(code) {
 
   const consume = (str) => {
     skip_spaces();
-    for (var i = 0; i < str.length; ++i) {
+    for (let i = 0; i < str.length; ++i) {
       if (code[idx + i] !== str[i]) {
-        var found = code.slice(idx, idx+12).replace(/\n/g,"\\n");
+        const found = code.slice(idx, idx + 12).replace(/\n/g,"\\n");
         throw "Expected '" + str[i] + "', found '" + found + "...'.";
       }
     }
@@ -56,7 +63,7 @@ function parse(code) {
 
   const parse_name = () => {
     skip_spaces();
-    var nm = "";
+    let nm = "";
     while (idx < code.length && /\w/.test(code[idx])) {
       nm += code[idx++];
     }
@@ -65,18 +72,18 @@ function parse(code) {
 
   const parse_lam = () => {
     if (match("{")) {
-      var name = parse_name();
-      var skip = consume("}");
-      var body = parse_term();
+      const name = parse_name();
+      const skip = consume("}");
+      const body = parse_term();
       return Lam(name, body);
     }
   };
 
   const parse_app = () => {
     if (match("(")) {
-      var func = parse_term();
-      var argm = parse_term();
-      var skip = consume(")");
+      const func = parse_term();
+      const argm = parse_term();
+      const skip = consume(")");
       return App(func, argm);
     }
   };
@@ -107,14 +114,15 @@ function parse(code) {
   };
 
   const parse_var = () => {
-    var name = parse_name();
+    const name = parse_name();
     if (name.length !== 0) {
       return Var(name);
     }
+    return null;
   };
 
   const parse_term = () => {
-    var term
+    const term
       =  parse_lam()
       || parse_app()
       || parse_par()
@@ -124,18 +132,18 @@ function parse(code) {
   };
 
   const parse_env = () => {
-    var name = parse_name();
+    const name = parse_name();
     if (name.length > 0) {
-      var term = parse_term();
+      const term = parse_term();
       env[name] = () => copy(term, env);
       parse_env();
     };
     return env;
   };
 
-  var idx = 0;
-  var env = {};
-  var nam = {};
+  let idx = 0;
+  const env = {};
+  const nam = {};
 
   parse_env();
 

--- a/syntax.js
+++ b/syntax.js
@@ -9,7 +9,7 @@ function show(term) {
     case Lam: {
       const name = term.name;
       const body = show(term.body);
-      return `${name} ${body}`;
+      return `{${name}} ${body}`;
     }
     case App: {
       const func = show(term.func);

--- a/syntax.js
+++ b/syntax.js
@@ -14,7 +14,7 @@ function show(term) {
     case App: {
       const func = show(term.func);
       const argm = show(term.argm);
-      return `(${func} ${argm })`;
+      return `(${func} ${argm})`;
     }
     case Par: {
       const val0 = show(term.val0);


### PR DESCRIPTION
Nice project! 
I would like to suggest upgrade existing code a little.

- [x] use classid tags instead `ctor` strings
- [x] use template strings
- [x] use `const` instead `var` where possible for avoid variable shadowing